### PR TITLE
Prepare 0.3.2.1 release.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@byteverse/l3c

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,11 @@
+name: build
+on:
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  call-workflow:
+    uses: byteverse/.github/.github/workflows/build-matrix.yaml@main
+    with:
+      cabal-file: http-interchange.cabal

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,10 @@
+name: release
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  call-workflow:
+    uses: byteverse/.github/.github/workflows/release.yaml@main
+    secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Revision history for http-interchange
 
-## 0.3.?.? -- 2024-??-??
+## 0.3.2.1 -- 2024-02-07
 
 * List test suite file dependencies in `extra-source-files` so that Hackage
   is able to run the test suite.
+* Update package metadata.
 
 ## 0.3.2.0 -- 2024-01-16
 

--- a/http-interchange.cabal
+++ b/http-interchange.cabal
@@ -1,34 +1,40 @@
-cabal-version:   3.0
-name:            http-interchange
-version:         0.3.2.1
-license:         BSD-3-Clause
-license-file:    LICENSE
-author:          Andrew Martin
-maintainer:      andrew.thaddeus@gmail.com
-synopsis:        Types and serialization for HTTP
+cabal-version:      3.0
+name:               http-interchange
+version:            0.3.2.1
+license:            BSD-3-Clause
+license-file:       LICENSE
+author:             Andrew Martin
+maintainer:         amartin@layer3com.com
+homepage:           https://github.com/byteverse/http-interchange
+bug-reports:        https://github.com/byteverse/http-interchange/issues
+synopsis:           Types and serialization for HTTP
 description:
   Types and serialization for HTTP. This includes things like request
   line, status line, and headers. There is also a collection type
   for headers that supports fast, case-insensitive lookup.
 
-copyright:       2023 Andrew Martin
-category:        Data
-build-type:      Simple
+copyright:          2023 Andrew Martin
+category:           Data
+build-type:         Simple
 extra-doc-files:
   CHANGELOG.md
   README.md
+
 extra-source-files:
   golden/request/*.json
-  golden/request/*.txt
-  golden/request/*.input
   golden/request/*.output
-  golden/response/*.json
-  golden/response/*.txt
   golden/response/*.input
   golden/response/*.output
 
+tested-with:        GHC ==9.4.8 || ==9.6.3 || ==9.8.1
+
+common build-settings
+  default-language: GHC2021
+  ghc-options:      -Wall -Wunused-packages
+
 library
-  ghc-options:      -Wall -O2
+  import:          build-settings
+  ghc-options:     -O2
   exposed-modules:
     Http.Bodied
     Http.Header
@@ -46,15 +52,13 @@ library
     , primitive   >=0.9.0
     , text        >=2.0
 
-  hs-source-dirs:   src
-  default-language: GHC2021
+  hs-source-dirs:  src
 
 test-suite test
-  ghc-options:      -Wall
-  default-language: GHC2021
-  type:             exitcode-stdio-1.0
-  hs-source-dirs:   test
-  main-is:          Main.hs
+  import:         build-settings
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is:        Main.hs
   build-depends:
     , aeson             >=2.1
     , base              >=4.16.3.0
@@ -66,3 +70,7 @@ test-suite test
     , primitive         >=0.9.0
     , tasty             >=1.4.3
     , tasty-golden      >=2.3.5
+
+source-repository head
+  type:     git
+  location: git://github.com/byteverse/http-interchange.git


### PR DESCRIPTION
Updated package metadata.
Use new .github workflows.
Transferred repo back to byteverse.